### PR TITLE
Fix problem with import MomentJS and rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,5 @@
     }
   ],
   "cordovaPlatforms": [],
-  "description": "superacao-app: An Ionic project",
-  "config": {
-      "ionic_rollup": "./config/rollup.config.js"
-  }
+  "description": "superacao-app: An Ionic project"
 }

--- a/src/components/calendar-picker/calendar-picker.ts
+++ b/src/components/calendar-picker/calendar-picker.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { NavController } from 'ionic-angular';
 import { CalendarNewEventPage } from '../../pages/calendar/new-event/new-event';
 import { DateUtil } from '../../providers/util/date-util';
-import * as moment from 'moment';
+import moment from 'moment';
 import 'moment/locale/pt-br';
 
 @Component({

--- a/src/pipes/date-custom-pipe.ts
+++ b/src/pipes/date-custom-pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 import 'moment/locale/pt-br';
 
 

--- a/src/providers/util/date-util.ts
+++ b/src/providers/util/date-util.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 import 'moment/locale/pt-br';
 
 @Injectable()


### PR DESCRIPTION
Solução para quem está com dificuldades ao inicialiar o app. O moment na sua versão mais recente agora é compativel totalmente com o TypeScript, e com isso sua forma de exportação mudou. Estava ocorrendo outro probleminha de incompatibilidade com o rollup e as variareis de ambiente. Eu simplemente removi o objeto "config" no package.json, e funcionou aqui... Isso eu ainda não sei dizer se é a solução mais ideal kkkk