### PR TITLE
app-140: elimina erro do logout

### DIFF
--- a/src/providers/database/user-storage-service.ts
+++ b/src/providers/database/user-storage-service.ts
@@ -39,7 +39,7 @@ export class UserStorageService {
       }
     }
 
-    this.db = this.af.database.object('/users/' + result.uid)
+    this.db = this.af.database.object(`/users/${result.uid}`)
     this.db.set(data)
   }
 
@@ -47,7 +47,7 @@ export class UserStorageService {
     return new Promise((resolve) => {
       this.af.auth.subscribe((user) => {
         if(user) {
-          this.af.database.object('/users/' + user.uid).subscribe((data) => {
+          this.af.database.object(`/users/${user.uid}`).subscribe((data) => {
             resolve(data)
           })
         }
@@ -60,7 +60,7 @@ export class UserStorageService {
     return new Observable((subject) => {
       this.af.auth.subscribe((user) => {
         if(user) {
-          this.af.database.object('/users/' + user.uid).subscribe((data) => {
+          this.af.database.object(`/users/${user.uid}`).subscribe((data) => {
               subject.next(data)
               datas = data
           })
@@ -71,35 +71,35 @@ export class UserStorageService {
 
   updateUser(user, uid) {
     delete user.$key
-    this.db = this.af.database.object('/users/' + uid)
+    this.db = this.af.database.object(`/users/${uid}`)
     this.db.set(user)
   }
 
   findUser(uid) {
     return new Promise((resolve) => {
-      this.db = this.af.database.object('/users/' + uid).subscribe((userDatas) => {
+      this.db = this.af.database.object(`/users/${uid}`).subscribe((userDatas) => {
         resolve(userDatas)
       })
     })
   }
 
   findUserObs(uid) : any {
-    return this.af.database.object('/users/' + uid)
+    return this.af.database.object(`/users/${uid}`)
   }
 
-  setEmotion(emotion, uidUser) {
-    this.db = this.af.database.object('/users/' + uidUser)
+  setEmotion(emotion, userUid) {
+    this.db = this.af.database.object(`/users/${userUid}`)
     this.db.update({"emotion" : emotion})
   }
 
   updateLastAccess(date, userUid) {
-    this.db = this.af.database.object('/users/' + userUid)
+    this.db = this.af.database.object(`/users/${userUid}`)
     this.db.update({"other_datas/last_access" : date})
   }
 
   updateTokenDevice(userUid) {
     this.utils.getPushDeviceToken().then((device) => {
-      this.db = this.af.database.object('/users/' + userUid)
+      this.db = this.af.database.object(`/users/${userUid}`)
       this.db.update({"other_datas/token_device": device})
     }).catch((err) => {
       console.log('Push notification desativado!')

--- a/src/providers/database/user-storage-service.ts
+++ b/src/providers/database/user-storage-service.ts
@@ -46,9 +46,11 @@ export class UserStorageService {
   getUser() {
     return new Promise((resolve) => {
       this.af.auth.subscribe((user) => {
-        this.af.database.object('/users/' + user.uid).subscribe((data) => {
-          resolve(data)
-        })
+        if(user) {
+          this.af.database.object('/users/' + user.uid).subscribe((data) => {
+            resolve(data)
+          })
+        }
       })
     })
   }
@@ -57,10 +59,12 @@ export class UserStorageService {
     let datas
     return new Observable((subject) => {
       this.af.auth.subscribe((user) => {
-        this.af.database.object('/users/' + user.uid).subscribe((data) => {
-            subject.next(data)
-            datas = data
-        })
+        if(user) {
+          this.af.database.object('/users/' + user.uid).subscribe((data) => {
+              subject.next(data)
+              datas = data
+          })
+        }
       })
     })
   }


### PR DESCRIPTION
O problema do logout tem a ver com as permissoes do banco de dados. Para resolver precisamos alterar as regras no firebase para as seguintes:

```
{
  "rules": {
    ".read": true,
    ".write": "auth != null"
  }
}
```

Isso flexibiliza a permissao de leitura.

Depois de fazer isso ja sera possivel fazer logout no aplicativo, mas vai gerar um erro no log do browser logo depois do logout. Esse PR vai eliminar esse erro.